### PR TITLE
chore: update CI matrix to include Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Development Status :: 5 - Production/Stable",
   "License :: OSI Approved :: MIT License",
   "Typing :: Typed",


### PR DESCRIPTION
## Summary
- [ -] Tests added/updated
- [ -] Docs updated
- [ +] CI green

## Rationale
Add support python 3.13, 3.14

## Checklist
- [ +] I ran `ruff`, `mypy`, and `pytest`
- [ -] I updated `CHANGELOG.md` (if user-visible change)
